### PR TITLE
fix(pillars): center pillars in their container

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -654,6 +654,8 @@ html {
   .pillars-container {
     flex: 1;
     max-width: 580px;
+    padding-top: 0;
+    padding-bottom: 40px;
   }
 
   .impact-content h2,
@@ -672,7 +674,6 @@ html {
   }
 
   .pillar-card {
-    padding-top: 42px;
     max-width: 120px;
   }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -668,7 +668,6 @@ html {
   }
 
   .pillars-wrapper {
-    justify-content: flex-start;
     height: 542px;
   }
 


### PR DESCRIPTION
- Center pillars in their container by removing justify-content: flex-start